### PR TITLE
Fix pagination

### DIFF
--- a/src/contentPage/MyWork/index.tsx
+++ b/src/contentPage/MyWork/index.tsx
@@ -20,6 +20,7 @@ const ContentMyWork: React.FC = () => {
 	const [filterData, setFilterData] = useState(dataMyWork)
 
 	const aplicationFilter = (button: string) => {
+		setCurrentPage(1)
 		if (button === ButtonNames.All) {
 			setFilterData(dataMyWork)
 		}


### PR DESCRIPTION
When you apply a filter, the paging always switches to the first page.